### PR TITLE
Adapt to new unicodes api response

### DIFF
--- a/src/fontra_rcjk/backend_mysql.py
+++ b/src/fontra_rcjk/backend_mysql.py
@@ -319,8 +319,7 @@ class RCJKMySQLBackend:
 
 
 def _unicodesFromGlyphInfo(glyphInfo):
-    unicode_hex = glyphInfo.get("unicode_hex")
-    return [int(unicode_hex, 16)] if unicode_hex else []
+    return glyphInfo.get("unicodes", [])
 
 
 def getUpdatedTimeStamp(info):


### PR DESCRIPTION
Adapt to the fix for https://github.com/googlefonts/django-robo-cjk/issues/57, as implemented in https://github.com/googlefonts/django-robo-cjk/commit/6bad3ed58606292728e5229931732721f10cfe39 and https://github.com/googlefonts/django-robo-cjk/commit/39d564221e6510f71a6b710e998f7f3e11d1671f