### PR TITLE
Further improvements regarding glyph/layer deletion/creation

### DIFF
--- a/src/fontra_rcjk/backend_mysql.py
+++ b/src/fontra_rcjk/backend_mysql.py
@@ -212,16 +212,13 @@ class RCJKMySQLBackend:
                         return_data=False,
                         return_layers=False,
                     )
-                for existingLayerName in existingLayerData:
-                    if existingLayerName not in layerGlyphs:
-                        logger.info(
-                            f"Deleting layer {existingLayerName} of {glyphName}"
-                        )
-                        await self._callGlyphMethod(
-                            glyphName,
-                            "layer_delete",
-                            existingLayerName,
-                        )
+                for layerName in set(existingLayerData) - set(layerGlyphs):
+                    logger.info(f"Deleting layer {layerName} of {glyphName}")
+                    await self._callGlyphMethod(
+                        glyphName,
+                        "layer_delete",
+                        layerName,
+                    )
                 self._glyphCache[glyphName] = layerGlyphs
         finally:
             unlockResponse = await self._callGlyphMethod(

--- a/src/fontra_rcjk/backend_mysql.py
+++ b/src/fontra_rcjk/backend_mysql.py
@@ -309,9 +309,8 @@ class RCJKMySQLBackend:
                 del self._rcjkGlyphInfo[glyphName]
                 latestTimeStamp = max(latestTimeStamp, glyphInfo["deleted_at"])
             # else:
-            # A layer got deleted, but we also receive that glyph as
-            # a regular changed glyph, via its layer_updated_at
-            # timestamp. We can ignore here.
+            # A layer got deleted, but we also receive that glyph as a regular changed
+            # glyph, via its layers_updated_at timestamp -- we should ignore here.
 
         for typeCode, typeName in _glyphTypes:
             for glyphInfo in responseData[typeName]:


### PR DESCRIPTION
- If a layer does not exist, create it
- If a layer existed before, and is no longer needed, delete it
- Don't depend on whether we happen to have glif data cached to see if a write to the DB is needed or not
- Adapt to django-rcjk api improvement: deleted *layers* are now also reflected in the layers_updated_at field, so we don't have to treat them special anymore (https://github.com/googlefonts/django-robo-cjk/pull/89/commits/ddc3cd881c202532645ed3263ee5223d2e8957d7 of https://github.com/googlefonts/django-robo-cjk/pull/89)