### PR TITLE
Allow incompatible components in variations

### DIFF
--- a/src/fontra_rcjk/base.py
+++ b/src/fontra_rcjk/base.py
@@ -135,7 +135,6 @@ def serializeGlyph(layerGlyphs, axisDefaults):
 
     dcNames = [c.name for c in defaultComponents]
     defaultComponentLocations = [compo.location for compo in defaultComponents]
-    componentNames = [c.name for c in layers["foreground"].glyph.components]
 
     sources = [Source(name="<default>", layerName="foreground")]
     variationGlyphData = defaultGlyph.lib.get("robocjk.variationGlyphs", ())
@@ -172,7 +171,6 @@ def serializeGlyph(layerGlyphs, axisDefaults):
         if components:
             layerGlyph.components = components
 
-        assert componentNames == [c.name for c in layerGlyph.components]
         location = varDict["location"]
         sources.append(Source(name=sourceName, location=location, layerName=layerName))
 
@@ -187,8 +185,6 @@ def serializeGlyph(layerGlyphs, axisDefaults):
 def serializeComponents(
     deepComponents, axisDefaults, dcNames, neutralComponentLocations
 ):
-    if dcNames is not None:
-        assert len(deepComponents) == len(dcNames)
     if neutralComponentLocations is None:
         neutralComponentLocations = [{}] * len(deepComponents)
     components = []
@@ -287,22 +283,10 @@ def unserializeGlyph(glyphName, glyph, unicodes, defaultLocation):
     return layerGlyphs
 
 
-def unserializeComponents(variableComponents, referenceNames=None):
-    addNames = True
-    if referenceNames is None:
-        referenceNames = [None] * len(variableComponents)
-    else:
-        if len(variableComponents) != len(referenceNames):
-            raise RCJKFormatError("variation has an incompatible number of components")
-        addNames = False
+def unserializeComponents(variableComponents):
     components = []
-    for compo, refName in zip(variableComponents, referenceNames):
-        if addNames:
-            compoDict = dict(name=compo.name)
-        else:
-            if compo.name != refName:
-                raise RCJKFormatError("variation has incompatible components")
-            compoDict = {}
+    for compo in variableComponents:
+        compoDict = dict(name=compo.name)
         compoDict.update(
             coord=compo.location,
             transform=unconvertTransformation(compo.transformation),

--- a/src/fontra_rcjk/base.py
+++ b/src/fontra_rcjk/base.py
@@ -242,7 +242,6 @@ def unserializeGlyph(glyphName, glyph, unicodes, defaultLocation):
         defaultGlyph.lib["robocjk.axes"] = [asdict(axis) for axis in glyph.axes]
 
     deepComponents = unserializeComponents(defaultGlyph.variableComponents)
-    deepComponentNames = [dc["name"] for dc in deepComponents]
     if deepComponents:
         defaultGlyph.lib["robocjk.deepComponents"] = deepComponents
 
@@ -257,9 +256,7 @@ def unserializeGlyph(glyphName, glyph, unicodes, defaultLocation):
         if layerGlyph.width != defaultGlyph.width:
             varDict["width"] = layerGlyph.width
 
-        deepComponents = unserializeComponents(
-            layerGlyph.variableComponents, deepComponentNames
-        )
+        deepComponents = unserializeComponents(layerGlyph.variableComponents)
         if deepComponents:
             varDict["deepComponents"] = deepComponents
 

--- a/src/fontra_rcjk/base.py
+++ b/src/fontra_rcjk/base.py
@@ -17,10 +17,6 @@ from fontra.core.packedpath import PackedPathPointPen
 from fontTools.ufoLib.glifLib import readGlyphFromString, writeGlyphToString
 
 
-class RCJKFormatError(Exception):
-    pass
-
-
 class GLIFGlyph:
     def __init__(self):
         self.name = None  # Must be set to a string before we can write GLIF data


### PR DESCRIPTION
Allow incompatible components in variations, but do always store the component name in variation data.

Note: such glyphs do *not* work in RoboCJK: it will output plenty tracebacks. I tried to fix it, but I think I'm fine with RoboCJK just not being able to open these. There're work-in-progress glyphs, never final ones.