### PR TITLE
Allow long and bad layer names

### DIFF
--- a/src/fontra_rcjk/base.py
+++ b/src/fontra_rcjk/base.py
@@ -403,7 +403,9 @@ def makeSafeLayerName(layerName):
     and as a layer name for django-rcjk, which has a 50 character limit, and
     additionally will also use it as a file system name upon export.
     """
-    safeLayerName = layerName.translate(illegalCharactersMap)[:maxLayerNameLength]
+    safeLayerName = layerName.translate(illegalCharactersMap)
+    safeLayerName = "".join(c if ord(c) < 0x10000 else "_" for c in safeLayerName)
+    safeLayerName = safeLayerName[:maxLayerNameLength]
     if safeLayerName != layerName:
         layerNameHash = hashlib.sha256(layerName.encode("utf-8")).hexdigest()[
             :hexHashLength

--- a/src/fontra_rcjk/base.py
+++ b/src/fontra_rcjk/base.py
@@ -377,6 +377,10 @@ maxLayerNameLengthWithoutHash = maxLayerNameLength - 1 - hexHashLength
 
 
 def makeSafeLayerName(layerName):
+    """Make a layer name that is safe to use as a file name on the file system,
+    and as a layer name for django-rcjk, which has a 50 character limit, and
+    additionally will also use it as a file system name upon export.
+    """
     safeLayerName = layerName.translate(illegalCharactersMap)[:maxLayerNameLength]
     if safeLayerName != layerName:
         layerNameHash = hashlib.sha256(layerName.encode("utf-8")).hexdigest()[

--- a/src/fontra_rcjk/base.py
+++ b/src/fontra_rcjk/base.py
@@ -188,6 +188,12 @@ def serializeGlyph(layerGlyphs, axisDefaults):
             )
         )
 
+    if fontraLayerNameMapping:
+        layers = {
+            fontraLayerNameMapping.get(layerName, layerName): layer
+            for layerName, layer in layers.items()
+        }
+
     return VariableGlyph(
         name=defaultGlyph.name,
         axes=defaultGlyph.axes,

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -677,3 +677,24 @@ async def test_add_new_layer(writableTestFont):
     assert layerPath.exists()
     layerGlifPath = layerPath / f"{glyphName}.glif"
     assert layerGlifPath.exists()
+
+
+async def test_bad_layer_name(writableTestFont):
+    glyphName = "a"
+    glyphMap = await writableTestFont.getGlyphMap()
+    glyph = await writableTestFont.getGlyph(glyphName)
+    badLayerName = "boooo/oooold"
+
+    # layerPath = writableTestFont.path / "characterGlyph" / badLayerName
+    # assert not layerPath.exists()
+
+    glyph.sources.append(Source(name=badLayerName, layerName=badLayerName))
+    glyph.layers[badLayerName] = Layer(
+        glyph=StaticGlyph(xAdvance=500, path=makeTestPath())
+    )
+
+    await writableTestFont.putGlyph(glyph.name, glyph, glyphMap[glyphName])
+
+    # assert layerPath.exists()
+    # layerGlifPath = layerPath / f"{glyphName}.glif"
+    # assert layerGlifPath.exists()

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -699,6 +699,8 @@ layerNameMappingTestData = [
     "      <dict>",
     "        <key>boooo_oooold.75e003ed2da2</key>",
     "        <string>boooo/oooold</string>",
+    "        <key>boooo_ooooldboooo_ooooldboooo_ooooldb.360a3fdd78e6</key>",
+    "        <string>boooo/ooooldboooo/ooooldboooo/ooooldboooo/ooooldboooo/oooold</string>",
     "      </dict>",
     "      <key>robocjk.status</key>",
     "      <integer>0</integer>",
@@ -731,6 +733,18 @@ layerNameMappingTestData = [
     "          <key>status</key>",
     "          <integer>0</integer>",
     "        </dict>",
+    "        <dict>",
+    "          <key>layerName</key>",
+    "          <string>boooo_ooooldboooo_ooooldboooo_ooooldb.360a3fdd78e6</string>",
+    "          <key>location</key>",
+    "          <dict/>",
+    "          <key>on</key>",
+    "          <true/>",
+    "          <key>sourceName</key>",
+    "          <string>boooo/ooooldboooo/ooooldboooo/ooooldboooo/ooooldboooo/oooold</string>",
+    "          <key>status</key>",
+    "          <integer>0</integer>",
+    "        </dict>",
     "      </array>",
     "    </dict>",
     "  </lib>",
@@ -742,16 +756,17 @@ async def test_bad_layer_name(writableTestFont):
     glyphName = "a"
     glyphMap = await writableTestFont.getGlyphMap()
     glyph = await writableTestFont.getGlyph(glyphName)
-    badLayerName = "boooo/oooold"
-    safeLayerName = makeSafeLayerName(badLayerName)
 
-    layerPath = writableTestFont.path / "characterGlyph" / safeLayerName
-    assert not layerPath.exists()
+    for badLayerName in ["boooo/oooold", "boooo/oooold" * 5]:
+        safeLayerName = makeSafeLayerName(badLayerName)
 
-    glyph.sources.append(Source(name=badLayerName, layerName=badLayerName))
-    glyph.layers[badLayerName] = Layer(
-        glyph=StaticGlyph(xAdvance=500, path=makeTestPath())
-    )
+        layerPath = writableTestFont.path / "characterGlyph" / safeLayerName
+        assert not layerPath.exists()
+
+        glyph.sources.append(Source(name=badLayerName, layerName=badLayerName))
+        glyph.layers[badLayerName] = Layer(
+            glyph=StaticGlyph(xAdvance=500, path=makeTestPath())
+        )
 
     await writableTestFont.putGlyph(glyph.name, glyph, glyphMap[glyphName])
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,20 @@
+import pytest
+
+from fontra_rcjk.base import makeSafeLayerName
+
+
+@pytest.mark.parametrize(
+    "layerName, expectedSafeLayerName",
+    [
+        ("a", "a"),
+        ("a" * 50, "a" * 50),
+        ("á" * 50, "á" * 50),
+        ("a" * 51, "a" * 37 + ".bfc5fe0e3601"),
+        ("á" * 51, "á" * 37 + ".3c1a18fbe650"),
+        ("a/b", "a_b.c14cddc033f6"),
+        ("a+b", "a_b.300273daf0bb"),
+    ],
+)
+def test_safeLayerName(layerName, expectedSafeLayerName):
+    safeLayerName = makeSafeLayerName(layerName)
+    assert expectedSafeLayerName == safeLayerName

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -13,6 +13,7 @@ from fontra_rcjk.base import makeSafeLayerName
         ("á" * 51, "á" * 37 + ".3c1a18fbe650"),
         ("a/b", "a_b.c14cddc033f6"),
         ("a+b", "a_b.300273daf0bb"),
+        ("a👀b", "a_b.6815aba75bec"),
     ],
 )
 def test_safeLayerName(layerName, expectedSafeLayerName):


### PR DESCRIPTION
Fixes #67.

Map fontra layer names to safe (but unique) names that can be used in the file system and in the django-rcjk database, which has a 50 char layer name limit.

Relates to https://github.com/googlefonts/django-robo-cjk/issues/108, which can then be closed as "not planned".