### PR TITLE
Allow > BMP chars again in layer names

### DIFF
--- a/src/fontra_rcjk/base.py
+++ b/src/fontra_rcjk/base.py
@@ -404,7 +404,6 @@ def makeSafeLayerName(layerName):
     additionally will also use it as a file system name upon export.
     """
     safeLayerName = layerName.translate(illegalCharactersMap)
-    safeLayerName = "".join(c if ord(c) < 0x10000 else "_" for c in safeLayerName)
     safeLayerName = safeLayerName[:maxLayerNameLength]
     if safeLayerName != layerName:
         layerNameHash = hashlib.sha256(layerName.encode("utf-8")).hexdigest()[

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -13,7 +13,7 @@ from fontra_rcjk.base import makeSafeLayerName
         ("á" * 51, "á" * 37 + ".3c1a18fbe650"),
         ("a/b", "a_b.c14cddc033f6"),
         ("a+b", "a_b.300273daf0bb"),
-        ("a👀b", "a_b.6815aba75bec"),
+        ("a👀b", "a👀b"),
     ],
 )
 def test_safeLayerName(layerName, expectedSafeLayerName):


### PR DESCRIPTION
The workaround can be removed, now that https://github.com/googlefonts/django-robo-cjk/issues/109 has been fixed.

Fixes #75.