### PR TITLE
Remove code that cleans up component locations to be compatible

### DIFF
--- a/src/fontra_rcjk/backend_fs.py
+++ b/src/fontra_rcjk/backend_fs.py
@@ -10,7 +10,6 @@ from fontTools.ufoLib.filenames import userNameToFileName
 from .base import (
     GLIFGlyph,
     TimedCache,
-    getComponentAxisDefaults,
     serializeGlyph,
     standardFontLibItems,
     unpackAxes,
@@ -99,8 +98,7 @@ class RCJKBackend:
 
     async def getGlyph(self, glyphName):
         layerGlyphs = self._getLayerGlyphs(glyphName)
-        axisDefaults = getComponentAxisDefaults(layerGlyphs, self._tempGlyphCache)
-        return serializeGlyph(layerGlyphs, axisDefaults)
+        return serializeGlyph(layerGlyphs)
 
     def _getLayerGlyphs(self, glyphName):
         layerGlyphs = self._tempGlyphCache.get(glyphName)

--- a/src/fontra_rcjk/backend_mysql.py
+++ b/src/fontra_rcjk/backend_mysql.py
@@ -9,7 +9,6 @@ from fontra.backends.designspace import makeGlyphMapChange
 from .base import (
     GLIFGlyph,
     TimedCache,
-    getComponentAxisDefaults,
     serializeGlyph,
     standardFontLibItems,
     unpackAxes,
@@ -117,8 +116,7 @@ class RCJKMySQLBackend:
         if self._glyphMap is not None and glyphName not in self._glyphMap:
             return None
         layerGlyphs = await self._getLayerGlyphs(glyphName)
-        axisDefaults = getComponentAxisDefaults(layerGlyphs, self._glyphCache)
-        return serializeGlyph(layerGlyphs, axisDefaults)
+        return serializeGlyph(layerGlyphs)
 
     async def _getLayerGlyphs(self, glyphName):
         layerGlyphs = self._glyphCache.get(glyphName)


### PR DESCRIPTION
Remove code that cleans up component locations to be compatible: this A) was implemented wrong and B) is the responsibility of the client.

This fixes https://github.com/googlefonts/fontra/issues/708