### PR TITLE
Explicitly set "trailing comma" option value to avoid fallbacks to unexpected defaults.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,6 @@
   "quoteProps": "consistent",
   "singleQuote": false,
   "tabWidth": 2,
+  "trailingComma" : "es5",
   "useTabs": false
 }


### PR DESCRIPTION
### Problem

The code formatted using `prettier` with `pre-commit` is different from the code formatted when by the `JSPrettier` Sublime extension.

### Solution

Explicitly set "trailing comma" option value in `.prettierrc` to avoid fallbacks to unexpected defaults.
