### PR TITLE
Fix problem with recreated deleted glyph

### DIFF
--- a/src/fontra_rcjk/backend_mysql.py
+++ b/src/fontra_rcjk/backend_mysql.py
@@ -327,6 +327,10 @@ class RCJKMySQLBackend:
                 if self._glyphTimeStamps.get(glyphName) is None:
                     # We made this change ourselves
                     continue
+                if glyphInfo["id"] != self._rcjkGlyphInfo[glyphName]:
+                    # The glyph was recreated in the mean time, ignore
+                    continue
+
                 logger.info(f"Found deleted glyph {glyphName}")
                 glyphMapUpdates[glyphName] = None
                 del self._glyphMap[glyphName]

--- a/src/fontra_rcjk/backend_mysql.py
+++ b/src/fontra_rcjk/backend_mysql.py
@@ -327,8 +327,9 @@ class RCJKMySQLBackend:
                 if self._glyphTimeStamps.get(glyphName) is None:
                     # We made this change ourselves
                     continue
-                if glyphInfo["id"] != self._rcjkGlyphInfo[glyphName]:
-                    # The glyph was recreated in the mean time, ignore
+                _, storedGlyphID = self._rcjkGlyphInfo[glyphName]
+                if glyphInfo["glif_id"] != storedGlyphID:
+                    # The glyph was recreated in the meantime, ignore
                     continue
 
                 logger.info(f"Found deleted glyph {glyphName}")


### PR DESCRIPTION
A glyph that gets recreated after deletion has a different ID, and we should ignore the deleted_glifs entry while polling. This fixes a wrong "deleted glyph" external change event.