### PR TITLE
Always rebuild the project list when asking for the list

### DIFF
--- a/src/fontra_rcjk/projectmanager.py
+++ b/src/fontra_rcjk/projectmanager.py
@@ -161,11 +161,11 @@ class AuthorizedClient:
         return path in self.projectMapping
 
     async def getProjectList(self):
-        await self._setupProjectList()
+        await self._setupProjectList(True)
         return sorted(self.projectMapping)
 
-    async def _setupProjectList(self):
-        if self.projectMapping is not None:
+    async def _setupProjectList(self, forceRebuild=False):
+        if not forceRebuild and self.projectMapping is not None:
             return
         projectMapping = await self.rcjkClient.get_project_font_uid_mapping()
         projectMapping = {f"{p}/{f}": uids for (p, f), uids in projectMapping.items()}


### PR DESCRIPTION
We used to cache the project list for as long as the user is logged in. If the user is then added to a project, this project will still not appear on the landing page, even after reload.

Yet, it is important to cache the project list so that the projectAvalailable method can be fast.

Let's always rebuild the project list if we're asking for the full list, but not it we're checking whether a certain project is available.

This fixes #34.