### PR TITLE
Rename used-by method to something less ambiguous

### DIFF
--- a/src/fontra_rcjk/backend_mysql.py
+++ b/src/fontra_rcjk/backend_mysql.py
@@ -388,7 +388,7 @@ class RCJKMySQLBackend:
         del self._glyphMap[glyphName]
         self._glyphCache.pop(glyphName, None)
 
-    async def getGlyphsUsedBy(self, glyphName: str) -> list[str]:
+    async def findGlyphsThatUseGlyph(self, glyphName: str) -> list[str]:
         glyphInfo = self._rcjkGlyphInfo.get(glyphName)
         if glyphInfo is None:
             return []


### PR DESCRIPTION
Counterpart to https://github.com/googlefonts/fontra/pull/1214, which contains a breaking change.