### PR TITLE
Add support for user editable status definitions

### DIFF
--- a/src/fontra_rcjk/backend_fs.py
+++ b/src/fontra_rcjk/backend_fs.py
@@ -261,7 +261,7 @@ class RCJKBackend:
         customDataPath = self.path / FONTLIB_FILENAME
         if customDataPath.is_file():
             customData = json.loads(customDataPath.read_text(encoding="utf-8"))
-        return customData | standardCustomDataItems
+        return standardCustomDataItems | customData
 
     async def putCustomData(self, customData: dict[str, Any]) -> None:
         customDataPath = self.path / FONTLIB_FILENAME

--- a/src/fontra_rcjk/backend_fs.py
+++ b/src/fontra_rcjk/backend_fs.py
@@ -265,11 +265,6 @@ class RCJKBackend:
 
     async def putCustomData(self, customData: dict[str, Any]) -> None:
         customDataPath = self.path / FONTLIB_FILENAME
-        customData = {
-            k: v
-            for k, v in customData.items()
-            if k not in standardCustomDataItems or standardCustomDataItems[k] != v
-        }
         customDataPath.write_text(json.dumps(customData, indent=2), encoding="utf-8")
 
     async def watchExternalChanges(

--- a/src/fontra_rcjk/backend_fs.py
+++ b/src/fontra_rcjk/backend_fs.py
@@ -261,7 +261,7 @@ class RCJKBackend:
         customDataPath = self.path / FONTLIB_FILENAME
         if customDataPath.is_file():
             customData = json.loads(customDataPath.read_text(encoding="utf-8"))
-        return standardCustomDataItems | customData
+        return deepcopy(standardCustomDataItems) | customData
 
     async def putCustomData(self, customData: dict[str, Any]) -> None:
         customDataPath = self.path / FONTLIB_FILENAME

--- a/src/fontra_rcjk/backend_mysql.py
+++ b/src/fontra_rcjk/backend_mysql.py
@@ -220,7 +220,7 @@ class RCJKMySQLBackend:
         if customData is None:
             await self._getMiscFontItems()
             customData = self._tempFontItemsCache["customData"]
-        return customData
+        return deepcopy(customData)
 
     async def putCustomData(self, customData: dict[str, Any]) -> None:
         await self._getMiscFontItems()

--- a/src/fontra_rcjk/backend_mysql.py
+++ b/src/fontra_rcjk/backend_mysql.py
@@ -131,7 +131,7 @@ class RCJKMySQLBackend:
                     "features", ""
                 )
                 self._tempFontItemsCache["customData"] = (
-                    font_data["data"].get("fontlib", {}) | standardCustomDataItems
+                    standardCustomDataItems | font_data["data"].get("fontlib", {})
                 )
                 self._tempFontItemsCache.updateTimeOut()
                 del self._getMiscFontItemsTask

--- a/src/fontra_rcjk/base.py
+++ b/src/fontra_rcjk/base.py
@@ -521,28 +521,28 @@ standardCustomDataItems = {
     "fontra.sourceStatusFieldDefinitions": [
         {
             "label": "In progress",
-            "color": (1.0, 0.0, 0.0, 1.0),
+            "color": [1.0, 0.0, 0.0, 1.0],
             "value": 0,
             "isDefault": True,
         },
         {
             "label": "Checking-1",
-            "color": (1.0, 0.5, 0.0, 1.0),
+            "color": [1.0, 0.5, 0.0, 1.0],
             "value": 1,
         },
         {
             "label": "Checking-2",
-            "color": (1.0, 1.0, 0.0, 1.0),
+            "color": [1.0, 1.0, 0.0, 1.0],
             "value": 2,
         },
         {
             "label": "Checking-3",
-            "color": (0.0, 0.5, 1.0, 1.0),
+            "color": [0.0, 0.5, 1.0, 1.0],
             "value": 3,
         },
         {
             "label": "Validated",
-            "color": (0.0, 1.0, 0.5, 1.0),
+            "color": [0.0, 1.0, 0.5, 1.0],
             "value": 4,
         },
     ]

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -1091,9 +1091,9 @@ async def test_read_write_glyph_customData(writableTestFont):
 
 async def test_statusFieldDefinitions(writableTestFont):
     customData = await writableTestFont.getCustomData()
-    statusDefinitions = customData.get("fontra.sourceStatusFieldDefinitions")
+    statusDefinitions = customData["fontra.sourceStatusFieldDefinitions"]
     assert (
-        standardCustomDataItems.get("fontra.sourceStatusFieldDefinitions")
+        standardCustomDataItems["fontra.sourceStatusFieldDefinitions"]
         == statusDefinitions
     )
     newStatusDef = {
@@ -1109,7 +1109,7 @@ async def test_statusFieldDefinitions(writableTestFont):
     await writableTestFont.putCustomData(editedCustomData)
 
     newCustomData = await writableTestFont.getCustomData()
-    newStatusDefinitions = newCustomData.get("fontra.sourceStatusFieldDefinitions")
+    newStatusDefinitions = newCustomData["fontra.sourceStatusFieldDefinitions"]
 
     assert newStatusDefinitions[5] == newStatusDef
 

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -20,7 +20,7 @@ from fontra.core.classes import (
     unstructure,
 )
 
-from fontra_rcjk.base import makeSafeLayerName
+from fontra_rcjk.base import makeSafeLayerName, standardCustomDataItems
 
 dataDir = pathlib.Path(__file__).resolve().parent / "data"
 
@@ -1086,3 +1086,27 @@ async def test_read_write_glyph_customData(writableTestFont):
     async with contextlib.aclosing(reopenedFont):
         reopenedGlyph = await reopenedFont.getGlyph(glyphName)
     assert glyph == reopenedGlyph
+
+
+async def test_statusFieldDefinitions(writableTestFont):
+    customData = await writableTestFont.getCustomData()
+    statusDefinitions = customData.get("fontra.sourceStatusFieldDefinitions")
+    assert (
+        standardCustomDataItems.get("fontra.sourceStatusFieldDefinitions")
+        == statusDefinitions
+    )
+    newStatusDef = {
+        "color": [0, 0, 0, 1],
+        "label": "Rejected",
+        "value": 5,
+    }
+    statusDefinitionsCopy = statusDefinitions.copy()
+    statusDefinitionsCopy.append(newStatusDef)
+
+    await writableTestFont.putCustomData(
+        {"fontra.sourceStatusFieldDefinitions": statusDefinitionsCopy}
+    )
+    newCustomData = await writableTestFont.getCustomData()
+    newStatusDefinitions = newCustomData.get("fontra.sourceStatusFieldDefinitions")
+
+    assert newStatusDefinitions[5] == newStatusDef

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -1,4 +1,5 @@
 import contextlib
+import json
 import pathlib
 import shutil
 from importlib.metadata import entry_points
@@ -1100,13 +1101,19 @@ async def test_statusFieldDefinitions(writableTestFont):
         "label": "Rejected",
         "value": 5,
     }
-    statusDefinitionsCopy = statusDefinitions.copy()
-    statusDefinitionsCopy.append(newStatusDef)
+    statusDefinitions.append(newStatusDef)
 
-    await writableTestFont.putCustomData(
-        {"fontra.sourceStatusFieldDefinitions": statusDefinitionsCopy}
-    )
+    editedCustomData = customData | {
+        "fontra.sourceStatusFieldDefinitions": statusDefinitions
+    }
+    await writableTestFont.putCustomData(editedCustomData)
+
     newCustomData = await writableTestFont.getCustomData()
     newStatusDefinitions = newCustomData.get("fontra.sourceStatusFieldDefinitions")
 
     assert newStatusDefinitions[5] == newStatusDef
+
+    fontLibPath = writableTestFont.path / "fontLib.json"
+    fontLib = json.loads(fontLibPath.read_text())
+
+    assert editedCustomData == fontLib


### PR DESCRIPTION
Fixes #183 

I have also tested it with converting an existing file:
`fontra-copy XXX.fontra XXX.rcjk`
+ opening the .rcjk-file with fontra
+ adding a new status definition
+ set a glyph source to the new status color code
+ close everything
+ open it again and have a look if everything is still there -> it works for me.