### PR TITLE
Use commit hash for fontra dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,8 @@
       }
     },
     "node_modules/@fontra/core": {
-      "resolved": "https://gitpkg.vercel.app/googlefonts/fontra/src-js/fontra-core?main",
-      "integrity": "sha512-gLRvBO6ltz/74VHviMh1hSFGMjTBBvy0qbh8STenLWVvr0Dn/8ZJA33QAxeJM5QZ4/KF4oz73AF5Kv/ptqNY3Q==",
+      "resolved": "https://gitpkg.vercel.app/googlefonts/fontra/src-js/fontra-core?f811dbb",
+      "integrity": "sha512-Qe1vLrWwQuHCql9HbKIx2+YVQPxcPDEfy9syHd4UggdJm7k/NrX2N3wbgrT4zzeEH1rlwd5AD9TufGhVTlI+TQ==",
       "dependencies": {
         "@fontra/core": "file:",
         "bezier-js": "^6.1.4",
@@ -42,8 +42,8 @@
     },
     "node_modules/@fontra/projectmanager-filesystem": {
       "version": "0.0.1",
-      "resolved": "https://gitpkg.vercel.app/googlefonts/fontra/src-js/projectmanager-filesystem?main",
-      "integrity": "sha512-SqiSdp73nqVKEQqTmEth2/c8e82VEiQVea9LXvO1hxvkDV8Lllv9gK2hogcuSSEvCIILhO0n37YztSXyhsm/Rg=="
+      "resolved": "https://gitpkg.vercel.app/googlefonts/fontra/src-js/projectmanager-filesystem?f811dbb",
+      "integrity": "sha512-4PMgnLlogxyuGtZbCoUB2u0QOI6br/lxeqaELezz5NnahQwdy/4Aj7Hyq06j1kcYsQRYLDOVuMbHLWx4vP3Gug=="
     },
     "node_modules/@fontra/projectmanager-rcjk": {
       "resolved": "src-js/projectmanager-rcjk",
@@ -585,9 +585,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001701",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001701.tgz",
-      "integrity": "sha512-faRs/AW3jA9nTwmJBSO1PQ6L/EOgsB5HMQQq4iCu5zhPgVVgO/pZRHlmatwijZKetFw8/Pr4q6dEN8sJuq8qTw==",
+      "version": "1.0.30001702",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001702.tgz",
+      "integrity": "sha512-LoPe/D7zioC0REI5W73PeR1e1MLCipRGq/VkovJnd6Df+QVqT+vT33OXCp8QUd7kA7RZrHWxb1B36OQKI/0gOA==",
       "dev": true,
       "funding": [
         {
@@ -761,9 +761,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.110",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.110.tgz",
-      "integrity": "sha512-/p/OvOm6AfLtQteAHTUWwf+Vhh76PlluagzQlSnxMoOJ4R6SmAScWBrVev6rExJoUhP9zudN9+lBxoYUEmC1HQ==",
+      "version": "1.5.112",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.112.tgz",
+      "integrity": "sha512-oen93kVyqSb3l+ziUgzIOlWt/oOuy4zRmpwestMn4rhFWAoFJeFuCVte9F2fASjeZZo7l/Cif9TiyrdW4CwEMA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5110,8 +5110,8 @@
       "name": "@fontra/projectmanager-rcjk",
       "version": "0.0.1",
       "dependencies": {
-        "@fontra/core": "https://gitpkg.vercel.app/googlefonts/fontra/src-js/fontra-core?main",
-        "@fontra/projectmanager-filesystem": "https://gitpkg.vercel.app/googlefonts/fontra/src-js/projectmanager-filesystem?main"
+        "@fontra/core": "https://gitpkg.vercel.app/googlefonts/fontra/src-js/fontra-core?f811dbb",
+        "@fontra/projectmanager-filesystem": "https://gitpkg.vercel.app/googlefonts/fontra/src-js/projectmanager-filesystem?f811dbb"
       }
     }
   }

--- a/src-js/projectmanager-rcjk/package.json
+++ b/src-js/projectmanager-rcjk/package.json
@@ -10,7 +10,7 @@
     "projectmanager": "rcjk"
   },
   "dependencies": {
-    "@fontra/core": "https://gitpkg.vercel.app/googlefonts/fontra/src-js/fontra-core?main",
-    "@fontra/projectmanager-filesystem": "https://gitpkg.vercel.app/googlefonts/fontra/src-js/projectmanager-filesystem?main"
+    "@fontra/core": "https://gitpkg.vercel.app/googlefonts/fontra/src-js/fontra-core?f811dbb",
+    "@fontra/projectmanager-filesystem": "https://gitpkg.vercel.app/googlefonts/fontra/src-js/projectmanager-filesystem?f811dbb"
   }
 }


### PR DESCRIPTION
For now, use a commit hash instead of "main" for the fontra-core deps. This works around #226.